### PR TITLE
feat(ci): add release and package publishing workflows 

### DIFF
--- a/.github/workflows/release-node.yml
+++ b/.github/workflows/release-node.yml
@@ -1,0 +1,192 @@
+# Based on the napi-rs CI template, generated with:
+#   npx napi new s3z --enable-github-actions --enable-default-targets --enable-all-targets
+#
+# Customised for s3z: version computation, pre-release publishing,
+# branch triggers, and target trimming (no Windows i686, Android, WASI, FreeBSD).
+
+name: Release Node
+
+on:
+  push:
+    tags:
+      - "**[0-9]+.[0-9]+.[0-9]+*"
+    branches:
+      - "release/**"
+      - "node/**"
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-node-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  APP_NAME: s3z
+  WORKING_DIR: bindings/node
+  MACOSX_DEPLOYMENT_TARGET: "10.13"
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      is-prerelease: ${{ steps.version.outputs.is-prerelease }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: version
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            V="${GITHUB_REF#refs/tags/}"
+            V="${V#v}"
+            echo "version=$V" >> "$GITHUB_OUTPUT"
+            echo "is-prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            PKG_VERSION=$(node -p "require('./bindings/node/package.json').version")
+            TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
+            echo "version=${PKG_VERSION}-dev.${TIMESTAMP}" >> "$GITHUB_OUTPUT"
+            echo "is-prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: build - ${{ matrix.settings.target }}
+    needs: [version]
+    strategy:
+      fail-fast: false
+      matrix:
+        settings:
+          - host: macos-latest
+            target: x86_64-apple-darwin
+          - host: macos-latest
+            target: aarch64-apple-darwin
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - host: ubuntu-latest
+            target: x86_64-unknown-linux-musl
+            use-zig: true
+          - host: ubuntu-latest
+            target: aarch64-unknown-linux-gnu
+            use-zig: true
+          - host: ubuntu-latest
+            target: aarch64-unknown-linux-musl
+            use-zig: true
+    runs-on: ${{ matrix.settings.host }}
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.settings.target }}
+
+      - name: Cache cargo
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            ~/.napi-rs
+            .cargo-cache
+            bindings/target/
+          key: ${{ matrix.settings.target }}-cargo-${{ matrix.settings.host }}
+
+      - name: Install zig
+        if: ${{ matrix.settings.use-zig }}
+        uses: mlugg/setup-zig@v2
+        with:
+          version: 0.14.1
+
+      - name: Install cargo-zigbuild
+        if: ${{ matrix.settings.use-zig }}
+        uses: taiki-e/install-action@v2
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          tool: cargo-zigbuild
+
+      - name: Install dependencies
+        working-directory: ${{ env.WORKING_DIR }}
+        run: npm install
+
+      - name: Build native addon
+        working-directory: ${{ env.WORKING_DIR }}
+        shell: bash
+        run: |
+          BUILD_FLAGS="--platform --release --target ${{ matrix.settings.target }} --manifest-path Cargo.toml --output-dir ./artifacts"
+          if [[ "${{ matrix.settings.use-zig }}" == "true" ]]; then
+            npx napi build $BUILD_FLAGS -x
+          else
+            npx napi build $BUILD_FLAGS
+          fi
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v6
+        with:
+          name: bindings-${{ matrix.settings.target }}
+          path: ${{ env.WORKING_DIR }}/artifacts/*.node
+          if-no-files-found: error
+
+  publish:
+    name: Publish to npm
+    needs: [version, build]
+    if: ${{ github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Download all artifacts
+        uses: actions/download-artifact@v7
+        with:
+          pattern: bindings-*
+          path: ${{ env.WORKING_DIR }}/artifacts
+          merge-multiple: true
+
+      - name: Set package version
+        working-directory: ${{ env.WORKING_DIR }}
+        run: npm version ${{ needs.version.outputs.version }} --no-git-tag-version --allow-same-version
+
+      - name: Install dependencies and create npm dirs
+        working-directory: ${{ env.WORKING_DIR }}
+        run: |
+          npm install
+          npx napi create-npm-dirs --package-json-path package.json
+
+      - name: Move artifacts to platform packages
+        working-directory: ${{ env.WORKING_DIR }}
+        run: npx napi artifacts --package-json-path package.json --build-output-dir artifacts
+
+      - name: List packages
+        working-directory: ${{ env.WORKING_DIR }}
+        run: ls -lR npm/
+
+      - name: Publish to npm
+        if: ${{ needs.version.outputs.is-prerelease == 'false' }}
+        working-directory: ${{ env.WORKING_DIR }}
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish to npm (dev)
+        if: ${{ needs.version.outputs.is-prerelease == 'true' }}
+        working-directory: ${{ env.WORKING_DIR }}
+        run: npm publish --access public --provenance --tag dev
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/release-python.yml
+++ b/.github/workflows/release-python.yml
@@ -1,0 +1,171 @@
+# Based on the maturin CI template, generated with:
+#   maturin generate-ci github -m bindings/python/Cargo.toml --platform manylinux macos
+#
+# Customised for s3z: version computation, pre-release publishing,
+# branch triggers, and target trimming (no Windows — core uses Unix APIs).
+
+name: Release Python
+
+on:
+  push:
+    tags:
+      - "**[0-9]+.[0-9]+.[0-9]+*"
+    branches:
+      - "release/**"
+      - "python/**"
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: release-python-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  MANIFEST_PATH: bindings/python/Cargo.toml
+
+jobs:
+  version:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      is-prerelease: ${{ steps.version.outputs.is-prerelease }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: version
+        shell: bash
+        run: |
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
+            V="${GITHUB_REF#refs/tags/}"
+            V="${V#v}"
+            echo "version=$V" >> "$GITHUB_OUTPUT"
+            echo "is-prerelease=false" >> "$GITHUB_OUTPUT"
+          else
+            CARGO_VERSION=$(grep -m1 '^version' bindings/python/Cargo.toml | sed 's/.*"\(.*\)"/\1/')
+            TIMESTAMP=$(date -u +%Y%m%d%H%M%S)
+            echo "version=${CARGO_VERSION}.dev${TIMESTAMP}" >> "$GITHUB_OUTPUT"
+            echo "is-prerelease=true" >> "$GITHUB_OUTPUT"
+          fi
+
+  linux:
+    needs: [version]
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - runner: ubuntu-22.04
+            target: x86_64
+            manylinux: auto
+          - runner: ubuntu-22.04
+            target: aarch64
+            manylinux: "2_28"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Patch version for pre-release
+        if: ${{ needs.version.outputs.is-prerelease == 'true' }}
+        run: |
+          sed -i 's/^version = .*/version = "${{ needs.version.outputs.version }}"/' bindings/python/pyproject.toml
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter --manifest-path ${{ env.MANIFEST_PATH }}
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+          manylinux: ${{ matrix.platform.manylinux }}
+      - name: Upload wheels
+        uses: actions/upload-artifact@v6
+        with:
+          name: wheels-linux-${{ matrix.platform.target }}
+          path: dist
+
+  macos:
+    needs: [version]
+    runs-on: ${{ matrix.platform.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - runner: macos-15-intel
+            target: x86_64
+          - runner: macos-latest
+            target: aarch64
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+      - name: Patch version for pre-release
+        if: ${{ needs.version.outputs.is-prerelease == 'true' }}
+        run: |
+          sed -i.bak 's/^version = .*/version = "${{ needs.version.outputs.version }}"/' bindings/python/pyproject.toml
+      - name: Build wheels
+        uses: PyO3/maturin-action@v1
+        with:
+          target: ${{ matrix.platform.target }}
+          args: --release --out dist --find-interpreter --manifest-path ${{ env.MANIFEST_PATH }}
+          sccache: ${{ !startsWith(github.ref, 'refs/tags/') }}
+      - name: Upload wheels
+        uses: actions/upload-artifact@v6
+        with:
+          name: wheels-macos-${{ matrix.platform.target }}
+          path: dist
+
+  sdist:
+    needs: [version]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Patch version for pre-release
+        if: ${{ needs.version.outputs.is-prerelease == 'true' }}
+        run: |
+          sed -i 's/^version = .*/version = "${{ needs.version.outputs.version }}"/' bindings/python/pyproject.toml
+      - name: Build sdist
+        uses: PyO3/maturin-action@v1
+        with:
+          command: sdist
+          args: --out dist --manifest-path ${{ env.MANIFEST_PATH }}
+      - name: Upload sdist
+        uses: actions/upload-artifact@v6
+        with:
+          name: wheels-sdist
+          path: dist
+
+  publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'push' }}
+    needs: [version, linux, macos, sdist]
+    environment: release
+    permissions:
+      id-token: write
+      contents: write
+      attestations: write
+    steps:
+      - uses: actions/download-artifact@v7
+        with:
+          pattern: wheels-*
+          merge-multiple: true
+          path: dist
+
+      - name: Generate artifact attestation
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: "dist/*"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      # Version tags → publish as stable.
+      - name: Publish to PyPI
+        if: ${{ needs.version.outputs.is-prerelease == 'false' }}
+        run: uv publish dist/*
+
+      # Branch pushes → publish as pre-release.
+      - name: Publish to PyPI (dev)
+        if: ${{ needs.version.outputs.is-prerelease == 'true' }}
+        run: uv publish dist/*

--- a/README.md
+++ b/README.md
@@ -15,16 +15,8 @@ A very lightweight, high-throughput S3 library/client.
 
 ## Install the s3z CLI
 
-On Linux/macOS:
-
 ```bash
 curl --proto '=https' --tlsv1.2 -LsSf https://github.com/jaeaeich/s3z/releases/latest/download/s3z-cli-installer.sh | sh
-```
-
-On Windows:
-
-```powershell
-irm https://github.com/jaeaeich/s3z/releases/latest/download/s3z-cli-installer.ps1 | iex
 ```
 
 ### Build from source

--- a/bindings/node/package.json
+++ b/bindings/node/package.json
@@ -1,12 +1,30 @@
 {
-  "name": "s3z",
+  "name": "@jae_aeich/s3z",
   "version": "0.1.0",
   "description": "Node.js bindings for s3z — S3 ops, but fearlessly fast!",
   "main": "index.js",
   "types": "index.d.ts",
   "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/JaeAeich/s3z"
+  },
+  "devDependencies": {
+    "@napi-rs/cli": "3.6.2"
+  },
   "napi": {
-    "name": "s3z",
-    "triples": {}
-  }
+    "binaryName": "s3z",
+    "targets": [
+      "x86_64-apple-darwin",
+      "aarch64-apple-darwin",
+      "x86_64-unknown-linux-gnu",
+      "x86_64-unknown-linux-musl",
+      "aarch64-unknown-linux-gnu",
+      "aarch64-unknown-linux-musl"
+    ]
+  },
+  "files": [
+    "index.js",
+    "index.d.ts"
+  ]
 }

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,49 @@
+[changelog]
+body = """
+{%- macro remote_url() -%}
+  https://github.com/jaeaeich/s3z
+{%- endmacro -%}
+
+{% if version -%}
+  ## [{{ version | trim_start_matches(pat="v") }}] — {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+  ## [Unreleased]
+{% endif -%}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+  ### {{ group | striptags | trim | upper_first }}
+  {% for commit in commits %}
+    - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | upper_first }} \
+      ([{{ commit.id | truncate(length=7, end="") }}]({{ self::remote_url() }}/commit/{{ commit.id }}))\
+      {%- if commit.breaking %} **BREAKING**{% endif %}
+  {%- endfor %}
+{% endfor %}
+"""
+footer = ""
+header = """
+# Changelog
+
+All notable changes to this project will be documented in this file.\n
+"""
+trim = true
+
+[git]
+commit_parsers = [
+  { group = "Bug Fixes", message = "^fix" },
+  { group = "Build", message = "^build" },
+  { group = "CI/CD", message = "^ci" },
+  { group = "Documentation", message = "^doc" },
+  { group = "Features", message = "^feat" },
+  { group = "Miscellaneous", message = "^chore" },
+  { group = "Performance", message = "^perf" },
+  { group = "Refactoring", message = "^refactor" },
+  { group = "Testing", message = "^test" },
+  { message = "^chore\\(release\\)", skip = true },
+]
+conventional_commits = true
+filter_commits = false
+filter_unconventional = true
+protect_breaking_commits = false
+sort_commits = "oldest"
+split_commits = false
+tag_pattern = "v[0-9].*"

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -3,12 +3,11 @@ cargo-dist-version = "0.31.0"
 ci = "github"
 hosting = "github"
 install-path = "CARGO_HOME"
-installers = ["npm", "powershell", "shell"]
+installers = ["npm", "shell"]
 targets = [
   "aarch64-apple-darwin",
   "aarch64-unknown-linux-musl",
   "x86_64-apple-darwin",
-  "x86_64-pc-windows-msvc",
   "x86_64-unknown-linux-musl",
 ]
 


### PR DESCRIPTION
## What

Add CI workflows for publishing Python wheels to PyPI and Node native addons to npm. Drop Windows targets (core uses Unix-only APIs). Add git-cliff config for changelog generation.

## Why

Users need `pip install s3z` and `npm install @jae_aeich/s3z` to work. Previously only the CLI binary had a release pipeline via cargo-dist — no mechanism existed for publishing language bindings.

## How

- **Python (`release-python.yml`):** maturin-action builds wheels for Linux (x86_64, aarch64) and macOS (x86_64, aarch64). Publishes to PyPI via trusted publisher (OIDC) on version tags. Branch pushes (`release/*`, `python/*`) publish `.devN` pre-releases.
- **Node (`release-node.yml`):** napi-rs builds native addons for 6 targets (Linux gnu/musl × x86_64/aarch64, macOS x86_64/aarch64). Uses zig for cross-compilation. Publishes to npm with provenance on version tags. Branch pushes publish under the `dev` dist-tag.
- **Windows dropped:** `s3z` core uses `std::os::unix` and `write_all_at` — doesn't compile on Windows. Removed from cargo-dist, Python, and Node matrices.
- **`cliff.toml`:** git-cliff config for conventional commit changelog generation.
- **`package.json`:** Scoped as `@jae_aeich/s3z` (npm rejects unscoped `s3z`), added `@napi-rs/cli` devDependency, explicit platform targets, repository field for provenance verification.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] New functionality has tests
- [ ] Benchmark results included (if touching transfer hot paths)