### PR TITLE
chore: checks CI for PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,97 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: -Dwarnings
+
+jobs:
+  fmt:
+    name: rustfmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - run: rustup toolchain install nightly --component rustfmt
+      - run: cargo +nightly fmt --check
+
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo clippy --all-targets --all-features -- -D warnings
+
+  test:
+    name: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo test --workspace
+
+  doc:
+    name: doc
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo doc --workspace --no-deps
+        env:
+          RUSTDOCFLAGS: -Dwarnings
+
+  machete:
+    name: unused deps
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: taiki-e/install-action@cargo-machete
+      - run: cargo machete
+
+  deny:
+    name: cargo deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: EmbarkStudios/cargo-deny-action@v2
+
+  audit:
+    name: security audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+  ruff:
+    name: ruff (bench)
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: bench
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v6
+      - run: uv run ruff format --check .
+      - run: uv run ruff check .
+
+  docs-build:
+    name: docs site
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: docs
+    steps:
+      - uses: actions/checkout@v6
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun run build

--- a/.lefthook.yaml
+++ b/.lefthook.yaml
@@ -2,11 +2,12 @@ pre-commit:
   parallel: true
   commands:
     editorconfig:
+      glob: "**/*.{toml,yaml,yml,json,md,rs,py,ts,tsx,js,mjs}"
       run: mise x -- eclint fix {staged_files}
       stage_fixed: true
 
     toml-hygiene:
-      glob: "{*.toml,**/*.toml}"
+      glob: "**/*.toml"
       run: >
         mise x -- toml-sort --in-place --all --trailing-comma-inline-array {staged_files}
         && mise x -- taplo format {staged_files}
@@ -25,6 +26,18 @@ pre-commit:
     clippy:
       glob: "**/*.rs"
       run: cargo clippy --all-targets --all-features -- -D warnings
+
+    ruff-format:
+      glob: "bench/**/*.py"
+      root: bench
+      run: uv run ruff format {staged_files}
+      stage_fixed: true
+
+    ruff-check:
+      glob: "bench/**/*.py"
+      root: bench
+      run: uv run ruff check --fix {staged_files}
+      stage_fixed: true
 
 commit-msg:
   commands:

--- a/bench/bench/plot.py
+++ b/bench/bench/plot.py
@@ -146,8 +146,14 @@ def _plot_upload(run_dir: Path, meta: RunMeta, suffix: str, theme: Theme) -> Non
     _apply_theme(fig, [ax_time, ax_rss], theme)
 
     _draw_grouped_bars(
-        ax_time, rows, backends, tools, theme,
-        value_attr="mean", err_lo_attr="ci95_half", err_hi_attr="ci95_half",
+        ax_time,
+        rows,
+        backends,
+        tools,
+        theme,
+        value_attr="mean",
+        err_lo_attr="ci95_half",
+        err_hi_attr="ci95_half",
         annotate=lambda r: f"{r.mean:.2f}s",
     )
     ax_time.set_ylabel("Time (seconds, mean ± 95% CI)", fontsize=11, fontfamily="monospace")
@@ -155,15 +161,25 @@ def _plot_upload(run_dir: Path, meta: RunMeta, suffix: str, theme: Theme) -> Non
     ax_time.set_xticklabels([])
     ax_time.grid(axis="y", alpha=0.3, zorder=0)
     ax_time.legend(
-        loc="upper right", frameon=True, fancybox=False,
-        edgecolor=theme.fg, fontsize=10,
+        loc="upper right",
+        frameon=True,
+        fancybox=False,
+        edgecolor=theme.fg,
+        fontsize=10,
         prop={"family": "monospace"},
-        labelcolor=theme.fg, facecolor=theme.bg,
+        labelcolor=theme.fg,
+        facecolor=theme.bg,
     )
 
     _draw_grouped_bars(
-        ax_rss, rows, backends, tools, theme,
-        value_attr="rss_mb", err_lo_attr=None, err_hi_attr=None,
+        ax_rss,
+        rows,
+        backends,
+        tools,
+        theme,
+        value_attr="rss_mb",
+        err_lo_attr=None,
+        err_hi_attr=None,
         annotate=lambda r: f"{r.rss_mb:.0f}",
     )
     ax_rss.set_ylabel("Peak RSS (MB)", fontsize=11, fontfamily="monospace")
@@ -172,13 +188,22 @@ def _plot_upload(run_dir: Path, meta: RunMeta, suffix: str, theme: Theme) -> Non
 
     fig.suptitle(
         f"s3z upload  //  {total_mb} MB  //  {meta.commit_short}  //  profile={meta.profile}",
-        fontsize=13, fontfamily="monospace", fontweight="bold", color=theme.fg,
+        fontsize=13,
+        fontfamily="monospace",
+        fontweight="bold",
+        color=theme.fg,
     )
 
     machine = f"{meta.os} {meta.arch} / {meta.cpus} cores / {meta.memory_gb} GB"
     fig.text(
-        0.5, 0.01, machine,
-        ha="center", fontsize=9, fontfamily="monospace", color=theme.fg, alpha=0.55,
+        0.5,
+        0.01,
+        machine,
+        ha="center",
+        fontsize=9,
+        fontfamily="monospace",
+        color=theme.fg,
+        alpha=0.55,
     )
 
     plt.tight_layout(rect=(0, 0.04, 1, 0.97))
@@ -205,8 +230,14 @@ def _plot_list(run_dir: Path, meta: RunMeta, suffix: str, theme: Theme) -> None:
     _apply_theme(fig, [ax_time, ax_rss], theme)
 
     _draw_grouped_bars(
-        ax_time, rows, backends, tools, theme,
-        value_attr="mean", err_lo_attr="ci95_half", err_hi_attr="ci95_half",
+        ax_time,
+        rows,
+        backends,
+        tools,
+        theme,
+        value_attr="mean",
+        err_lo_attr="ci95_half",
+        err_hi_attr="ci95_half",
         annotate=lambda r: f"{r.mean:.3f}s",
     )
     ax_time.set_ylabel("Time (seconds, mean ± 95% CI)", fontsize=11, fontfamily="monospace")
@@ -214,15 +245,25 @@ def _plot_list(run_dir: Path, meta: RunMeta, suffix: str, theme: Theme) -> None:
     ax_time.set_xticklabels([])
     ax_time.grid(axis="y", alpha=0.3, zorder=0)
     ax_time.legend(
-        loc="upper right", frameon=True, fancybox=False,
-        edgecolor=theme.fg, fontsize=10,
+        loc="upper right",
+        frameon=True,
+        fancybox=False,
+        edgecolor=theme.fg,
+        fontsize=10,
         prop={"family": "monospace"},
-        labelcolor=theme.fg, facecolor=theme.bg,
+        labelcolor=theme.fg,
+        facecolor=theme.bg,
     )
 
     _draw_grouped_bars(
-        ax_rss, rows, backends, tools, theme,
-        value_attr="rss_mb", err_lo_attr=None, err_hi_attr=None,
+        ax_rss,
+        rows,
+        backends,
+        tools,
+        theme,
+        value_attr="rss_mb",
+        err_lo_attr=None,
+        err_hi_attr=None,
         annotate=lambda r: f"{r.rss_mb:.0f}",
     )
     ax_rss.set_ylabel("Peak RSS (MB)", fontsize=11, fontfamily="monospace")
@@ -231,13 +272,22 @@ def _plot_list(run_dir: Path, meta: RunMeta, suffix: str, theme: Theme) -> None:
 
     fig.suptitle(
         f"s3z list  //  {file_count} files  //  {meta.commit_short}  //  profile={meta.profile}",
-        fontsize=13, fontfamily="monospace", fontweight="bold", color=theme.fg,
+        fontsize=13,
+        fontfamily="monospace",
+        fontweight="bold",
+        color=theme.fg,
     )
 
     machine = f"{meta.os} {meta.arch} / {meta.cpus} cores / {meta.memory_gb} GB"
     fig.text(
-        0.5, 0.01, machine,
-        ha="center", fontsize=9, fontfamily="monospace", color=theme.fg, alpha=0.55,
+        0.5,
+        0.01,
+        machine,
+        ha="center",
+        fontsize=9,
+        fontfamily="monospace",
+        color=theme.fg,
+        alpha=0.55,
     )
 
     plt.tight_layout(rect=(0, 0.03, 1, 0.97))
@@ -264,8 +314,14 @@ def _plot_download(run_dir: Path, meta: RunMeta, suffix: str, theme: Theme) -> N
     _apply_theme(fig, [ax_time, ax_rss], theme)
 
     _draw_grouped_bars(
-        ax_time, rows, backends, tools, theme,
-        value_attr="mean", err_lo_attr="ci95_half", err_hi_attr="ci95_half",
+        ax_time,
+        rows,
+        backends,
+        tools,
+        theme,
+        value_attr="mean",
+        err_lo_attr="ci95_half",
+        err_hi_attr="ci95_half",
         annotate=lambda r: f"{r.mean:.2f}s",
     )
     ax_time.set_ylabel("Time (seconds, mean ± 95% CI)", fontsize=11, fontfamily="monospace")
@@ -273,15 +329,25 @@ def _plot_download(run_dir: Path, meta: RunMeta, suffix: str, theme: Theme) -> N
     ax_time.set_xticklabels([])
     ax_time.grid(axis="y", alpha=0.3, zorder=0)
     ax_time.legend(
-        loc="upper right", frameon=True, fancybox=False,
-        edgecolor=theme.fg, fontsize=10,
+        loc="upper right",
+        frameon=True,
+        fancybox=False,
+        edgecolor=theme.fg,
+        fontsize=10,
         prop={"family": "monospace"},
-        labelcolor=theme.fg, facecolor=theme.bg,
+        labelcolor=theme.fg,
+        facecolor=theme.bg,
     )
 
     _draw_grouped_bars(
-        ax_rss, rows, backends, tools, theme,
-        value_attr="rss_mb", err_lo_attr=None, err_hi_attr=None,
+        ax_rss,
+        rows,
+        backends,
+        tools,
+        theme,
+        value_attr="rss_mb",
+        err_lo_attr=None,
+        err_hi_attr=None,
         annotate=lambda r: f"{r.rss_mb:.0f}",
     )
     ax_rss.set_ylabel("Peak RSS (MB)", fontsize=11, fontfamily="monospace")
@@ -290,13 +356,22 @@ def _plot_download(run_dir: Path, meta: RunMeta, suffix: str, theme: Theme) -> N
 
     fig.suptitle(
         f"s3z download  //  {total_mb} MB  //  {meta.commit_short}  //  profile={meta.profile}",
-        fontsize=13, fontfamily="monospace", fontweight="bold", color=theme.fg,
+        fontsize=13,
+        fontfamily="monospace",
+        fontweight="bold",
+        color=theme.fg,
     )
 
     machine = f"{meta.os} {meta.arch} / {meta.cpus} cores / {meta.memory_gb} GB"
     fig.text(
-        0.5, 0.01, machine,
-        ha="center", fontsize=9, fontfamily="monospace", color=theme.fg, alpha=0.55,
+        0.5,
+        0.01,
+        machine,
+        ha="center",
+        fontsize=9,
+        fontfamily="monospace",
+        color=theme.fg,
+        alpha=0.55,
     )
 
     plt.tight_layout(rect=(0, 0.03, 1, 0.97))
@@ -383,18 +458,26 @@ def _draw_grouped_bars(
             err_hi.append(getattr(r, err_hi_attr) if err_hi_attr else 0.0)
             annotations.append(annotate(r))
 
-        color = theme.tool_colors.get(
-            tool, theme.fallback_colors[ti % len(theme.fallback_colors)]
-        )
+        color = theme.tool_colors.get(tool, theme.fallback_colors[ti % len(theme.fallback_colors)])
         ax.bar(
-            xs, vals, bar_width,
-            color=color, label=tool, zorder=3, edgecolor="none",
+            xs,
+            vals,
+            bar_width,
+            color=color,
+            label=tool,
+            zorder=3,
+            edgecolor="none",
         )
         if err_lo_attr or err_hi_attr:
             ax.errorbar(
-                xs, vals, yerr=[err_lo, err_hi],
-                fmt="none", ecolor=theme.error_color,
-                elinewidth=1.2, capsize=3, zorder=4,
+                xs,
+                vals,
+                yerr=[err_lo, err_hi],
+                fmt="none",
+                ecolor=theme.error_color,
+                elinewidth=1.2,
+                capsize=3,
+                zorder=4,
             )
 
         for x, v, hi, txt in zip(xs, vals, err_hi, annotations, strict=True):
@@ -402,8 +485,12 @@ def _draw_grouped_bars(
                 x,
                 v + hi + (max(vals) * 0.02 if vals else 0.05),
                 txt,
-                ha="center", va="bottom", fontsize=7.5,
-                fontfamily="monospace", color=theme.fg, alpha=theme.text_alpha,
+                ha="center",
+                va="bottom",
+                fontsize=7.5,
+                fontfamily="monospace",
+                color=theme.fg,
+                alpha=theme.text_alpha,
             )
 
     centers = [
@@ -412,5 +499,9 @@ def _draw_grouped_bars(
     ]
     ax.set_xticks(centers)
     ax.set_xticklabels(
-        backends, fontfamily="monospace", fontsize=11, fontweight="bold", color=theme.fg,
+        backends,
+        fontfamily="monospace",
+        fontsize=11,
+        fontweight="bold",
+        color=theme.fg,
     )

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -48,7 +48,7 @@ pub struct TransferConfig {
     /// Default part size hint (bytes). For multipart uploads, the actual
     /// part size is auto-computed from file size and concurrency — this
     /// value is used only as the fallback for `plan_parts` when called
-    /// directly. See [`crate::transfer::scheduler::compute_part_size`].
+    /// directly. The scheduler auto-computes the optimal part size.
     pub part_size: u64,
 }
 

--- a/crates/core/src/ops/upload.rs
+++ b/crates/core/src/ops/upload.rs
@@ -95,8 +95,8 @@ impl UploadRequest {
     /// Each part is streamed from disk through a 256 KiB buffer, so peak
     /// memory per file is roughly `concurrency_per_file * 256 KiB`.
     ///
-    /// Note: actual per-file concurrency is dynamically scaled by
-    /// [`scheduler::concurrency_for_size`] based on each file's size.
+    /// Note: actual per-file concurrency is dynamically scaled based
+    /// on each file's size.
     #[inline]
     #[must_use]
     pub fn new(

--- a/crates/core/src/transfer/multipart.rs
+++ b/crates/core/src/transfer/multipart.rs
@@ -105,7 +105,7 @@ async fn abort(
     upload_id: &str,
 ) -> Result<()> {
     let uri: Uri =
-        format!("{}/{bucket}/{}?uploadId={upload_id}", config.endpoint_url(), key.encoded(),)
+        format!("{}/{bucket}/{}?uploadId={upload_id}", config.endpoint_url(), key.encoded())
             .parse()?;
 
     let req = build_signed(Method::DELETE, uri, Bytes::new(), creds, &config.region)?;
@@ -129,7 +129,7 @@ async fn complete(
     xml.push_str("</CompleteMultipartUpload>");
 
     let uri: Uri =
-        format!("{}/{bucket}/{}?uploadId={upload_id}", config.endpoint_url(), key.encoded(),)
+        format!("{}/{bucket}/{}?uploadId={upload_id}", config.endpoint_url(), key.encoded())
             .parse()?;
 
     let req = build_signed(Method::POST, uri, Bytes::from(xml), creds, &config.region)?;

--- a/crates/core/src/transfer/scheduler.rs
+++ b/crates/core/src/transfer/scheduler.rs
@@ -105,7 +105,6 @@ pub(crate) fn plan_parts(file_size: u64, config: &TransferConfig) -> Vec<Part> {
         "file requires {num_parts} parts but S3 allows at most {MAX_S3_PARTS}; increase part_size"
     );
 
-    let num_parts = file_size.div_ceil(config.part_size);
     let capacity = usize::try_from(num_parts).unwrap_or(usize::MAX);
     let mut parts = Vec::with_capacity(capacity);
     let mut remaining = file_size;


### PR DESCRIPTION
## What

Add a CI workflow that gates PRs and pushes to main with lint, test, and
security checks. Expand lefthook pre-commit hooks to cover bench Python
code. Fix cargo doc and redundant code in core.

## Why

No CI existed on PRs — broken code could land on main unchecked. Bench
Python had no automated formatting enforcement.

## How

- **`.github/workflows/ci.yml`**: rustfmt, clippy, cargo test, cargo doc,
  cargo machete, cargo-deny, security audit, ruff (bench), docs site build.
  Uses rust-cache and concurrency groups.
- **`.lefthook.yaml`**: add ruff-format/ruff-check for `bench/**/*.py`,
  scope editorconfig glob to known extensions.
- **`crates/core`**: remove shadowed `num_parts` recomputation in
  `plan_parts`, replace intra-doc links to private items with prose.
- **`bench/bench/plot.py`**: apply ruff formatting.

## Checklist

- [x] `cargo test --workspace` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` is clean
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] New functionality has tests
- [ ] Benchmark results included (if touching transfer hot paths)